### PR TITLE
Update `src` path for htmlDependency

### DIFF
--- a/R/BBPselectInput.R
+++ b/R/BBPselectInput.R
@@ -6,7 +6,7 @@ BBPselectInput <- function(...) {
   dep <- htmltools::htmlDependency(
     name = "designkit",
     version = "0.1.0",
-    src = c(href = "inst/css"),
+    src = "inst/css",
     stylesheet = "big-bud-select.css"
   )
 


### PR DESCRIPTION
Hi Maya! I believe this should do the trick. I'm sure there's a lot more nuance to it, but I've always used the `src` argument to reference a directory and then specify CSS/JS dependencies within it ([example here](https://github.com/jdtrat/shinysurveys/blob/a1aab893cdf7af9c677319a7862db151dd466133/R/input_radioMatrixInput.R#L174)). 

If this is going to be a package package, you could also do this:

```r
dep <- htmltools::htmlDependency(
    name = "designkit",
    version = "0.1.0",
    package = "designkit", # specify me and src will automagically look in inst (I think)
    src = "css",
    stylesheet = "big-bud-select.css"
  )
```